### PR TITLE
chore!: Rename to `axum-jwks`.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,14 +1,14 @@
 [package]
-name = "auth0-axum"
+name = "axum-jwks"
 version = "0.1.2"
 edition = "2021"
 resolver = "2"
 license-file = "LICENSE"
 readme = "README.md"
-description = "Verify JWTs from a JWKS in Axum"
-homepage = "https://github.com/cdriehuys/auth0-axum"
-repository = "https://github.com/cdriehuys/auth0-axum"
-documentation = "https://docs.rs/auth0-axum"
+description = "Use a JSON Web Key Set (JWKS) to verify JWTs in Axum."
+homepage = "https://github.com/cdriehuys/axum-jwks"
+repository = "https://github.com/cdriehuys/axum-jwks"
+documentation = "https://docs.rs/axum-jwks"
 keywords = ["axum", "jwk", "jwks", "jwt"]
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html

--- a/README.md
+++ b/README.md
@@ -1,3 +1,3 @@
-# auth0-axum
+# axum-jwks
 
-An unofficial repository for verifying Auth0 JWTs in Axum.
+Use a JSON Web Key Set (JWKS) to verify JWTs in Axum.


### PR DESCRIPTION
The repository had nothing to do specifically with Auth0, so it has been
renamed.
