### PR TITLE
feat: Add `rustls` feature

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,10 +13,14 @@ keywords = ["axum", "jwk", "jwks", "jwt"]
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
+[features]
+default = ["reqwest/default-tls"]
+rustls = ["reqwest/rustls-tls"]
+
 [dependencies]
 axum = { version = "0.6", features = ["headers"] }
 jsonwebtoken = { version = "8", default-features = false }
-reqwest = { version = "0.11", features = ["json"] }
+reqwest = { version = "0.11", default-features = false, features = ["json"] }
 serde = { version = "1", features = ["derive"] }
 thiserror = { version = "1" }
 tracing = { version = "0.1" }


### PR DESCRIPTION
The `rustls` feature allows for using `rustls` instead of the native TLS
support provided by the OS.
