### PR TITLE
Support for more providers, support using openid-configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,8 @@ Use a [JSON Web Key Set (JWKS)][jwks] to verify JWTs in [Axum][axum].
 
 # Features
 
-* Pull a JWKS from an Authorization Server
+* Use an openid-configuration to get the setup from the Authorization Server.
+* Pull a JWKS directly from an Authorization Server
 * Verify JWTs signed by any key in the JWKS and provided as a bearer token in
   the `Authorization` header
 

--- a/src/jwks.rs
+++ b/src/jwks.rs
@@ -24,31 +24,28 @@ impl Jwks {
     /// Pull a JSON Web Key Set from a specific authority.
     ///
     /// # Arguments
-    /// * `authority` - The base domain that will be issuing keys. The JWKS info
-    ///   is pulled from `{authority}/.well-known/jwks.json`.
+    /// * `jwks_url` - The url which JWKS info is pulled from.
     /// * `audience` - The identifier of the consumer of the JWT. This will be
     ///   matched against the `aud` claim from the token.
     ///
     /// # Return Value
     /// The information needed to decode JWTs using any of the keys specified in
     /// the authority's JWKS.
-    pub async fn from_authority(authority: &str, audience: String) -> Result<Self, JwksError> {
-        Self::from_authority_with_client(&reqwest::Client::default(), authority, audience).await
+    pub async fn from_jwks_url(jwks_url: &str, audience: String) -> Result<Self, JwksError> {
+        Self::from_jwks_url_with_client(&reqwest::Client::default(), jwks_url, audience).await
     }
 
-    /// A version of [`from_authority`][Self::from_authority] that allows for
+    /// A version of [`from_jwks`][Self::from_jwks] that allows for
     /// passing in a custom [`Client`][reqwest::Client].
-    pub async fn from_authority_with_client(
+    pub async fn from_jwks_url_with_client(
         client: &reqwest::Client,
-        authority: &str,
+        jwks_url: &str,
         audience: String,
     ) -> Result<Self, JwksError> {
-        let jwks_url = format!("{}/.well-known/jwks.json", authority);
-        debug!(%authority, %jwks_url, "Fetching JSON Web Key Set.");
+        debug!(%jwks_url, "Fetching JSON Web Key Set.");
         let jwks: jwk::JwkSet = client.get(jwks_url).send().await?.json().await?;
-
         info!(
-            %authority,
+            %jwks_url,
             count = jwks.keys.len(),
             "Successfully pulled JSON Web Key Set."
         );

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -71,9 +71,9 @@
 //! }
 //!
 //! async fn create_router() -> Router<AppState> {
-//!     let jwks = Jwks::from_jwks_url(
+//!     let jwks = Jwks::from_oidc_url(
 //!         // The Authorization Server that signs the JWTs you want to consume.
-//!         "https://my-auth-server.example.com/.well-known/jwks.json",
+//!         "https://my-auth-server.example.com/.well-known/openid-configuration",
 //!         // The audience identifier for the application. This ensures that
 //!         // JWTs are intended for this application.
 //!         "https://my-api-identifier.example.com/".to_owned(),

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -71,9 +71,9 @@
 //! }
 //!
 //! async fn create_router() -> Router<AppState> {
-//!     let jwks = Jwks::from_authority(
+//!     let jwks = Jwks::from_jwks_url(
 //!         // The Authorization Server that signs the JWTs you want to consume.
-//!         "https://my-auth-server.example.com",
+//!         "https://my-auth-server.example.com/.well-known/jwks.json",
 //!         // The audience identifier for the application. This ensures that
 //!         // JWTs are intended for this application.
 //!         "https://my-api-identifier.example.com/".to_owned(),


### PR DESCRIPTION
Thanks for a great crate, I like it!

This has been tested with:
 - AzureAD: e.g. https://login.microsoftonline.com/common/v2.0/.well-known/openid-configuration
 - https://github.com/navikt/mock-oauth2-server

I am very open to do modifications to this PR