### PR TITLE
fix: packaging due to sub-directory

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -32,5 +32,5 @@ jobs:
           override: true
         if: ${{ steps.release.outputs.releases_created }}
 
-      - run: cargo publish --token ${{ secrets.CRATES_TOKEN }}
+      - run: cargo publish -p axum-jwks --token ${{ secrets.CRATES_TOKEN }}
         if: ${{ steps.release.outputs.releases_created }}

--- a/axum-jwks/src/lib.rs
+++ b/axum-jwks/src/lib.rs
@@ -1,5 +1,6 @@
-#![doc = include_str!("../../README.md")]
-
+//! axum-jwks allows for easily verifying JWTs in an axum application using any
+//! key from a JSON Web Key Set (JWKS).
+//!
 //! # Usage
 //!
 //! Here's a minimal working example of how you would authenticate via JWTs in a


### PR DESCRIPTION
Moving the published package to a subdirectory caused a few issues in
the publishing process. First, including the README in the library
documentation is difficult due to path differences during normal builds
vs during packaging. Second, we have to specify which package to publish
because the package is not at the repository root.
