### PR TITLE
Jwks from a pre-fetched JwkSet

### DIFF
--- a/axum-jwks/src/jwks.rs
+++ b/axum-jwks/src/jwks.rs
@@ -112,7 +112,7 @@ impl Jwks {
     pub fn from_jwk_set(
         jwk_set: jwk::JwkSet,
         audience: Option<&str>,
-        alg: Option<jsonwebtoken::Algorithm>
+        alg: Option<jsonwebtoken::Algorithm>,
     ) -> Result<Self, JwksError> {
         let mut keys = HashMap::new();
         for jwk in jwk_set.keys {
@@ -149,7 +149,7 @@ impl Jwks {
                         key_id: kid,
                         algorithm: other.to_owned(),
                     }
-                        .into())
+                    .into())
                 }
             }
         }

--- a/axum-jwks/src/jwks.rs
+++ b/axum-jwks/src/jwks.rs
@@ -97,7 +97,7 @@ impl Jwks {
             "Successfully pulled JSON Web Key Set."
         );
 
-        Self::from_jwk_set(&jwks, audience, alg).await
+        Self::from_jwk_set(jwks, audience, alg)
     }
 
     ///

--- a/axum-jwks/src/jwks.rs
+++ b/axum-jwks/src/jwks.rs
@@ -28,7 +28,6 @@ struct Oid {
 
 impl Jwks {
     /// Pull a JSON Web Key Set from a specific authority.
-
     ///
     /// # Arguments
     /// * `oidc_url` - The url with Openid-configuration.

--- a/axum-jwks/src/jwks.rs
+++ b/axum-jwks/src/jwks.rs
@@ -111,7 +111,7 @@ impl Jwks {
     /// The information needed to decode JWTs using any of the keys specified in
     /// the authority's JWKS.
     pub fn from_jwk_set(
-        jwk_set: &jwk::JwkSet,
+        jwk_set: jwk::JwkSet,
         audience: Option<&str>,
         alg: Option<jsonwebtoken::Algorithm>
     ) -> Result<Self, JwksError> {


### PR DESCRIPTION
The main reason that I request this change is that would like to cache the response from a slow `.well-known/jwks.json` endpoint. And to simplify the caching i want to use serde to serialize and deserialize the output so it can be easely stored.
But the `Jwks` struct does not implement serde, while the `JwkSet` does.

The change basically moves code handling the from `JwkSet` to `Jwks` into a separate function with similar paramters as the existing functions.

I have looked into multiple different options.
1. Implement serde for the `Jwks` struct, but this involved updating sub crates so its a bigger process.
2. Copy the current code handling the from `JwkSet` to `Jwks` into my code, but the `Jwk` struct is not `pub`.
Even if its simpler to just add `pub` to the `Jwk` struct we probably dont want to expose it.

I think the approach is the best of both worlds, one negative thing I see about it is that we are now taking in a parameter from a external crate which we have little control over.

Another positive thing about moving this out of the current functions, we could now have `reqwest` as a feature flag.
This would in turn support cases like:
* Smaller binary sizes by not including the `reqwest` dependency
* Http client agnostic