### PR TITLE
feat: support axum 0.8

### DIFF
--- a/axum-jwks/Cargo.toml
+++ b/axum-jwks/Cargo.toml
@@ -14,10 +14,10 @@ keywords = ["axum", "jwk", "jwks", "jwt"]
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-axum = "0.7"
-axum-extra = { version = "0.9.0", features = ["typed-header"] }
+axum = "^0.8"
+axum-extra = { version = "^0.10", features = ["typed-header"] }
 jsonwebtoken = { version = "8", default-features = false }
-reqwest = { version = "0.11", default-features = false, features = ["json"] }
+reqwest = { version = "^0.11", default-features = false, features = ["json"] }
 serde = { version = "1", features = ["derive"] }
 thiserror = { version = "1" }
 tracing = { version = "0.1" }

--- a/axum-jwks/src/claims.rs
+++ b/axum-jwks/src/claims.rs
@@ -1,5 +1,4 @@
 use axum::{
-    async_trait,
     extract::{FromRef, FromRequestParts},
     http::request::Parts,
     response::IntoResponse,
@@ -78,7 +77,6 @@ pub trait ParseTokenClaims {
     type Rejection: IntoResponse + From<TokenError>;
 }
 
-#[async_trait]
 impl<S, C> FromRequestParts<S> for Claims<C>
 where
     C: DeserializeOwned + ParseTokenClaims,

--- a/axum-jwks/src/token.rs
+++ b/axum-jwks/src/token.rs
@@ -1,5 +1,4 @@
 use axum::{
-    async_trait,
     extract::FromRequestParts,
     http::{request::Parts, StatusCode},
     response::IntoResponse,
@@ -29,8 +28,10 @@ impl core::fmt::Debug for Token {
     }
 }
 
-#[async_trait]
-impl<S> FromRequestParts<S> for Token {
+impl<S> FromRequestParts<S> for Token
+where
+    S: Send + Sync,
+{
     type Rejection = TokenError;
 
     async fn from_request_parts(parts: &mut Parts, _state: &S) -> Result<Self, Self::Rejection> {


### PR DESCRIPTION
This PR adds support for axum 0.8. The main difference is the removal of async_trait, which is not required (and available) anymore in axum 0.8