### PR TITLE
feat: do not panic on unsupported algorithms

### DIFF
--- a/axum-jwks/Cargo.toml
+++ b/axum-jwks/Cargo.toml
@@ -16,7 +16,7 @@ keywords = ["axum", "jwk", "jwks", "jwt"]
 [dependencies]
 axum = "0.8"
 axum-extra = { version = "0.10.0", features = ["typed-header"] }
-jsonwebtoken = { version = "8", default-features = false }
+jsonwebtoken = { version = "9", default-features = false }
 reqwest = { version = "0.11", default-features = false, features = ["json"] }
 serde = { version = "1", features = ["derive"] }
 thiserror = { version = "1" }

--- a/axum-jwks/src/jwks.rs
+++ b/axum-jwks/src/jwks.rs
@@ -142,6 +142,8 @@ impl Jwks {
                         );
                         if let Some(audience) = audience {
                             validation.set_audience(&[audience.to_string()]);
+                        } else {
+                            validation.validate_aud = false;
                         }
 
                         keys.insert(

--- a/axum-jwks/src/lib.rs
+++ b/axum-jwks/src/lib.rs
@@ -86,6 +86,10 @@
 //!         .with_state(AppState { jwks })
 //! }
 //! ```
+//!
+//! # Unsupported algorithms
+//! In case a JWK uses an unsupported key algorithm this is logged as warning but otherwise ignored.
+//! Tokens signed by that key will *not* be valid.
 
 mod claims;
 mod jwks;

--- a/examples/middleware/Cargo.toml
+++ b/examples/middleware/Cargo.toml
@@ -9,6 +9,7 @@ edition = "2021"
 serde = "1"
 tokio = { version = "1", features = ["full"] }
 tower = "0.4"
-axum = "0.7"
+axum = "0.8"
 axum-jwks = { path = "../../axum-jwks" }
-axum-extra = { version = "0.9.0", features = ["typed-header"] }
+axum-extra = { version = "0.10.0", features = ["typed-header"] }
+tracing-subscriber = "0.3.19"

--- a/examples/middleware/src/main.rs
+++ b/examples/middleware/src/main.rs
@@ -8,6 +8,7 @@ mod auth;
 
 #[tokio::main]
 async fn main() {
+    tracing_subscriber::fmt::init();
     let jwks = Jwks::from_oidc_url(
         // The Authorization Server that signs the JWTs you want to consume.
         "https://my-auth-server.example.com/.well-known/openid-configuration",


### PR DESCRIPTION
There is a panic happening right now when trying to parse a JWK set which contains keys with algorithms that are not supported. This is for example the case when using Keycloak since by default there are keys using RSA-OAEP. This is causing a panic in the jsonwebtoken version that is currently used. See https://github.com/Keats/jsonwebtoken/issues/252 for details.

This PR upgrades jsonwebtoken to a newer version which includes the fix to not panic anymore. But that also means that this lib needs to decide on what to do in that case. For me just logging each not supported JWK is enough. Not sure what you would think though.

If something like this would not be supported to work without errors or panics the only solution when using this crate would be to parse the JWKs by yourself and then filtering the ones that are not supported which in my opinion would not be a great solution. 

While at it I also updated the axum version in the example and added a tracing_subscriber which makes this easy to reproduce and see the logs.